### PR TITLE
fix: v1.0 sha256

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About rq
 ========
 
-Home: https://github.com/nvie/rq/
+Home: https://github.com/rq/rq/
 
 Package license: BSD 2-Clause
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/nvie/rq/archive/v{{ version }}.tar.gz
-  sha256: aa74372ea0e8ab98077e7b9a690ace0300ca8c9b20bd9c085ee13aa6a2aa4e4c
+  url: https://github.com/rq/rq/archive/v{{ version }}.tar.gz
+  sha256: 612347de9529c6d50a97c0c69c4f16b22e100c9d036d92f7273e52b9afd4cc7e
 
 build:
   noarch: python
@@ -22,13 +22,13 @@ requirements:
   build:
     - python
     - pip
-    - redis-py >=2.7.0
+    - redis-py >=3.0
     - click >=3.0
 
   run:
     - python
     - setuptools
-    - redis-py >=2.7.0
+    - redis-py >=3.0
     - click >=3.0
 
 test:
@@ -43,7 +43,7 @@ test:
     - rqworker --help
 
 about:
-  home: https://github.com/nvie/rq/
+  home: https://github.com/rq/rq/
   license: BSD 2-Clause
   license_file: LICENSE
   license_family: BSD


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Rq v1.0 is not present in conda-forge. Sha256 does not match source file.

<!--
Please add any other relevant info below:
-->
