### PR TITLE
bump: update rq to 2.6.1

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,10 +1,6 @@
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-python_min:
-- '3.9'

--- a/README.md
+++ b/README.md
@@ -102,12 +102,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -134,7 +134,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/rq-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,6 +1,8 @@
+schema_version: 1
+
 context:
-  name: "rq"
-  version: "2.4.1"
+  name: rq
+  version: 2.6.1
 
 package:
   name: ${{ name|lower }}
@@ -8,12 +10,12 @@ package:
 
 source:
   url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/rq-${{ version }}.tar.gz
-  sha256: 40ba01af3edacc008ab376009a3a547278d2bfe02a77cd4434adc0b01788239f
+  sha256: db5c0d125ac9dbd4438f9a5225ea3e64050542b416fd791d424e2ab5b2853289
 
 build:
   number: 0
   noarch: python
-  script: ${{ PYTHON }} -m pip install . -vv
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   python:
     entry_points:
       - rq = rq.cli:main
@@ -22,22 +24,24 @@ build:
 
 requirements:
   host:
-    - python ${{ python_min }}.*
+    - python >=3.9
     - pip
     - hatchling
   run:
-    - python >=${{ python_min }}
-    - redis-py >=4.0.0,!=6.0.0
-    - click >=5.0.0
+    - python >=3.9
+    - croniter
+    - redis-py >=3.5,!=6
+    - click >=5
 
 tests:
   - python:
       imports:
         - rq
-        - rq.cli
-        - rq.contrib
-      python_version: ${{ python_min }}.*
-  - script:
+      pip_check: true
+  - requirements:
+      run:
+        - pip
+    script:
       - rq --help
       - rqinfo --help
       - rqworker --help


### PR DESCRIPTION
Update version from 2.4.1 to 2.6.1

The recipe is generated by `grayskull pypi -u rq`, and tested with `rattler-build build`

Closes: #46
Closes: #47
Closes: #48
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [-] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [-] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [-] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
