### PR TITLE
Update rq to 2.9.0

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   name: "rq"
-  version: "2.7.0"
+  version: "2.9.0"
 
 package:
   name: ${{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/rq-${{ version }}.tar.gz
-  sha256: c2156fc7249b5d43dda918c4355cfbf8d0d299a5cdd3963918e9c8daf4b1e0c0
+  sha256: db5dfc1e1fe80ef977fd557d4305107dcf99a80b33d381c9a06e8a2bb11730e5
 
 build:
   number: 0


### PR DESCRIPTION
Bumps rq to the latest PyPI release, 2.9.0.

- Update version + sha256
- Run requirements (`click >=5`, `croniter`, `redis-py >=3.5,!=6`) match upstream `requires_dist` and are unchanged from 2.7.0
- No rerender changes